### PR TITLE
fixed integration with hatch-terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ See lf documentation for more.
 - `lf_terminal_cmd` name of Kakoune command that will spawn terminal/tmux window
   with lf. It *must* expose `$kak_session` and `$kak_client` environmental variables.
   It also must set variable `KAKLF` to `yes`. By default it uses `hatch-terminal` command
-  from [Kakoune-extra]. I couldn't get it to work with build-in `terminal`
-  command, PRs welcome.
+  from [Kakoune-extra].
 
 ## TODO
 

--- a/rc/lf.kak
+++ b/rc/lf.kak
@@ -43,9 +43,7 @@ define-command lf -docstring 'Open/close lf as file browser' %{
 }
 
 define-command -hidden lf-spawn-new %{
-    hatch-terminal %{
-        env KAKLF="yes" lf $(basename $kak_buffile)
-    }
+    hatch-terminal %{ sh -c 'env KAKLF="yes" kak_client=$KAK_CLIENT kak_session=$KAK_SESSION lf $(dirname $kak_buffile)' }
 }
 
 define-command -hidden lf-send-command \


### PR DESCRIPTION
- `sh -c` is required, because hatch-terminal sometimes uses the user's shell, which can be fish, for example.
- The command needs to be on one line, because I encountered an issue, where hatch-terminal would somehow crop the actual command, and instead run just `env`. This probably isn't actually needed with `sh -c`, but I added it just in case.
- `kak_(session|client)` are required, because hatch-terminal only provides `KAK_(SESSION|CLIENT)`; the lowercase variants are available in some cases, but the uppercase ones are deliberate, and always available.
- `dirname`, because... I think you defined it with `basename` by mistake
